### PR TITLE
Add left arrow to LeanReplace

### DIFF
--- a/autoload/lean.vim
+++ b/autoload/lean.vim
@@ -14,6 +14,7 @@ function! lean#replace()
 		%s/\\\//∨/ge
 		%s/<->/↔/ge
 		%s/->/→/ge
+		%s/<-/←/ge
 		%s/<=/≤/ge
 		%s/>=/≥/ge
 		%s/\~=/≠/ge


### PR DESCRIPTION
From Theorem Proving in Lean, chapter 4

> Here the left arrow before add_assoc tells rewrite to use the identity
> in the opposite direction. (You can enter it with \l or use the ascii
> equivalent, <-.)